### PR TITLE
Enhancement #47 : Splitting RPICAM2DNG.convert() into sub functions

### DIFF
--- a/pidng/dng.py
+++ b/pidng/dng.py
@@ -1,155 +1,156 @@
 import struct
-import sys
-import os, io
-import time
-import array
-import getopt
-import platform
-import operator
-import errno
 
-class Type:
-    # TIFF Type Format = (Tag TYPE value, Size in bytes of one instance)
-    Invalid = (0,0) # Should not be used
-    Byte = (1,1) # 8-bit unsigned
-    Ascii = (2,1) # 7-bit ASCII code
-    Short = (3,2) # 16-bit unsigned
-    Long = (4,4) # 32-bit unsigned
-    Rational = (5,8) # 2 Longs, numerator:denominator
-    Sbyte = (6,1) # 8 bit signed integer
-    Undefined = (7,1) # 8 bit byte containing anything
-    Sshort = (8,2) # 16 bit signed
-    Slong = (9,4) # 32 bit signed
-    Srational = (10,8) # 2 Slongs, numerator:denominator
-    Float = (11,4) # 32bit float IEEE
-    Double = (12,8) # 64bit double IEEE
-    IFD = (13,4) # IFD (Same as Long)
+from addict import Dict
 
-class Tag:
-    Invalid                     = (0,Type.Invalid)
-    NewSubfileType              = (254,Type.Long)
-    ImageWidth                  = (256,Type.Long)
-    ImageLength                 = (257,Type.Long)
-    BitsPerSample               = (258,Type.Short)
-    Compression                 = (259,Type.Short)
-    PhotometricInterpretation   = (262,Type.Short)
-    FillOrder                   = (266,Type.Short)
-    ImageDescription            = (270,Type.Ascii)
-    Make                        = (271,Type.Ascii)
-    Model                       = (272,Type.Ascii)
-    StripOffsets                = (273,Type.Long)
-    Orientation                 = (274,Type.Short)
-    SamplesPerPixel             = (277,Type.Short)
-    RowsPerStrip                = (278,Type.Short)
-    StripByteCounts             = (279,Type.Long)
-    XResolution                 = (282,Type.Rational)
-    YResolution                 = (283,Type.Rational)
-    PlanarConfiguration         = (284,Type.Short)
-    ResolutionUnit              = (296,Type.Short)
-    Software                    = (305,Type.Ascii)
-    DateTime                    = (306,Type.Ascii)
-    Artist                      = (315,Type.Ascii)
-    Predictor                   = (317,Type.Short)
-    TileWidth                   = (322,Type.Short)
-    TileLength                  = (323,Type.Short)
-    TileOffsets                 = (324,Type.Long)
-    TileByteCounts              = (325,Type.Long)
-    SubIFD                      = (330,Type.IFD)
-    XMP_Metadata                = (700,Type.Undefined)
-    CFARepeatPatternDim         = (33421,Type.Short)
-    CFAPattern                  = (33422,Type.Byte)
-    Copyright                   = (33432,Type.Ascii)
-    ExposureTime                = (33434,Type.Rational)
-    FNumber                     = (33437,Type.Rational)
-    EXIF_IFD                    = (34665,Type.IFD)
-    ExposureProgram             = (34850,Type.Short)
-    PhotographicSensitivity     = (34855,Type.Short)
-    SensitivityType             = (34864,Type.Short)
-    ExifVersion                 = (36864,Type.Undefined)
-    DateTimeOriginal            = (36867,Type.Ascii)
-    ShutterSpeedValue           = (37377,Type.Srational)
-    ApertureValue               = (37378,Type.Rational)
-    ExposureBiasValue           = (37380,Type.Srational)
-    MaxApertureValue            = (37381,Type.Rational)
-    SubjectDistance             = (37382,Type.Rational)
-    MeteringMode                = (37383,Type.Short)
-    Flash                       = (37385,Type.Short)
-    FocalLength                 = (37386,Type.Rational)
-    TIFF_EP_StandardID          = (37398,Type.Byte)
-    SubsecTime                  = (37520,Type.Ascii)
-    SubsecTimeOriginal          = (37521,Type.Ascii)
-    FocalPlaneXResolution       = (41486,Type.Rational)
-    FocalPlaneYResolution       = (41487,Type.Rational)
-    FocalPlaneResolutionUnit    = (41488,Type.Short)
-    FocalLengthIn35mmFilm       = (41989,Type.Short)
-    EXIFPhotoBodySerialNumber   = (42033,Type.Ascii)
-    EXIFPhotoLensModel          = (42036,Type.Ascii)
-    DNGVersion                  = (50706,Type.Byte)
-    DNGBackwardVersion          = (50707,Type.Byte)
-    UniqueCameraModel           = (50708,Type.Ascii)
-    CFAPlaneColor               = (50710,Type.Byte)
-    CFALayout                   = (50711,Type.Short)
-    LinearizationTable          = (50712,Type.Short)
-    BlackLevelRepeatDim         = (50713,Type.Short)
-    BlackLevel                  = (50714,Type.Short)
-    WhiteLevel                  = (50717,Type.Short)
-    DefaultScale                = (50718,Type.Rational)
-    DefaultCropOrigin           = (50719,Type.Long)
-    DefaultCropSize             = (50720,Type.Long)
-    ColorMatrix1                = (50721,Type.Srational)
-    ColorMatrix2                = (50722,Type.Srational)
-    CameraCalibration1          = (50723,Type.Srational)
-    CameraCalibration2          = (50724,Type.Srational)
-    AnalogBalance               = (50727,Type.Rational)
-    AsShotNeutral               = (50728,Type.Rational)
-    BaselineExposure            = (50730,Type.Srational)
-    BaselineNoise               = (50731,Type.Rational)
-    BaselineSharpness           = (50732,Type.Rational)
-    BayerGreenSplit             = (50733,Type.Long)
-    LinearResponseLimit         = (50734,Type.Rational)
-    CameraSerialNumber          = (50735,Type.Ascii)
-    AntiAliasStrength           = (50738,Type.Rational)
-    ShadowScale                 = (50739,Type.Rational)
-    DNGPrivateData              = (50740,Type.Byte)
-    MakerNoteSafety             = (50741,Type.Short)
-    CalibrationIlluminant1      = (50778,Type.Short)
-    CalibrationIlluminant2      = (50779,Type.Short)
-    BestQualityScale            = (50780,Type.Rational)
-    RawDataUniqueID             = (50781,Type.Byte)
-    ActiveArea                  = (50829,Type.Long)
-    CameraCalibrationSignature  = (50931,Type.Ascii)
-    ProfileCalibrationSignature = (50932,Type.Ascii)
-    NoiseReductionApplied       = (50935,Type.Rational)
-    ProfileName                 = (50936,Type.Ascii)
-    ProfileHueSatMapDims        = (50937,Type.Long)
-    ProfileHueSatMapData1       = (50938,Type.Float)
-    ProfileHueSatMapData2       = (50939,Type.Float)
-    ProfileToneCurve            = (50940,Type.Float)
-    ProfileEmbedPolicy          = (50941,Type.Long)
-    ForwardMatrix1              = (50964, Type.Srational)
-    ForwardMatrix2              = (50965, Type.Srational)
-    PreviewApplicationName      = (50966,Type.Ascii)
-    PreviewApplicationVersion   = (50967,Type.Ascii)
-    PreviewSettingsDigest       = (50969,Type.Byte)
-    PreviewColorSpace           = (50970,Type.Long)
-    PreviewDateTime             = (50971,Type.Ascii)
-    NoiseProfile                = (51041,Type.Double)
-    TimeCodes                   = (51043,Type.Byte)
-    FrameRate                   = (51044,Type.Srational)
-    OpcodeList1                 = (51008,Type.Undefined)
-    OpcodeList2                 = (51009,Type.Undefined)
-    ReelName                    = (51081,Type.Ascii)
-    BaselineExposureOffset      = (51109,Type.Srational) # 1.4 Spec says rational but mentions negative values?
-    DefaultBlackRender          = (51110,Type.Long)
-    NewRawImageDigest           = (51111,Type.Byte)
-    
-    
+
+Type = Dict({
+    # TIFF Type Format': (Tag TYPE value, Size in bytes of one instance)
+    'Invalid': (0,0), # Should not be used
+    'Byte': (1,1), # 8-bit unsigned
+    'Ascii': (2,1), # 7-bit ASCII code
+    'Short': (3,2), # 16-bit unsigned
+    'Long': (4,4), # 32-bit unsigned
+    'Rational': (5,8), # 2 Longs, numerator:denominator
+    'Sbyte': (6,1), # 8 bit signed integer
+    'Undefined': (7,1), # 8 bit byte containing anything
+    'Sshort': (8,2), # 16 bit signed
+    'Slong': (9,4), # 32 bit signed
+    'Srational': (10,8), # 2 Slongs, numerator:denominator
+    'Float': (11,4), # 32bit float IEEE
+    'Double': (12,8), # 64bit double IEEE
+    'IFD': (13,4), # IFD (Same as Long)
+})
+
+Tag = Dict({
+    'Invalid'                     : (0,Type.Invalid),
+    'NewSubfileType'              : (254,Type.Long),
+    'ImageWidth'                  : (256,Type.Long),
+    'ImageLength'                 : (257,Type.Long),
+    'BitsPerSample'               : (258,Type.Short),
+    'Compression'                 : (259,Type.Short),
+    'PhotometricInterpretation'   : (262,Type.Short),
+    'FillOrder'                   : (266,Type.Short),
+    'ImageDescription'            : (270,Type.Ascii),
+    'Make'                        : (271,Type.Ascii),
+    'Model'                       : (272,Type.Ascii),
+    'StripOffsets'                : (273,Type.Long),
+    'Orientation'                 : (274,Type.Short),
+    'SamplesPerPixel'             : (277,Type.Short),
+    'RowsPerStrip'                : (278,Type.Short),
+    'StripByteCounts'             : (279,Type.Long),
+    'XResolution'                 : (282,Type.Rational),
+    'YResolution'                 : (283,Type.Rational),
+    'PlanarConfiguration'         : (284,Type.Short),
+    'ResolutionUnit'              : (296,Type.Short),
+    'Software'                    : (305,Type.Ascii),
+    'DateTime'                    : (306,Type.Ascii),
+    'Artist'                      : (315,Type.Ascii),
+    'Predictor'                   : (317,Type.Short),
+    'TileWidth'                   : (322,Type.Short),
+    'TileLength'                  : (323,Type.Short),
+    'TileOffsets'                 : (324,Type.Long),
+    'TileByteCounts'              : (325,Type.Long),
+    'SubIFD'                      : (330,Type.IFD),
+    'XMP_Metadata'                : (700,Type.Undefined),
+    'CFARepeatPatternDim'         : (33421,Type.Short),
+    'CFAPattern'                  : (33422,Type.Byte),
+    'Copyright'                   : (33432,Type.Ascii),
+    'ExposureTime'                : (33434,Type.Rational),
+    'FNumber'                     : (33437,Type.Rational),
+    'EXIF_IFD'                    : (34665,Type.IFD),
+    'ExposureProgram'             : (34850,Type.Short),
+    'PhotographicSensitivity'     : (34855,Type.Short),
+    'SensitivityType'             : (34864,Type.Short),
+    'ExifVersion'                 : (36864,Type.Undefined),
+    'DateTimeOriginal'            : (36867,Type.Ascii),
+    'ShutterSpeedValue'           : (37377,Type.Srational),
+    'ApertureValue'               : (37378,Type.Rational),
+    'ExposureBiasValue'           : (37380,Type.Srational),
+    'MaxApertureValue'            : (37381,Type.Rational),
+    'SubjectDistance'             : (37382,Type.Rational),
+    'MeteringMode'                : (37383,Type.Short),
+    'Flash'                       : (37385,Type.Short),
+    'FocalLength'                 : (37386,Type.Rational),
+    'TIFF_EP_StandardID'          : (37398,Type.Byte),
+    'SubsecTime'                  : (37520,Type.Ascii),
+    'SubsecTimeOriginal'          : (37521,Type.Ascii),
+    'FocalPlaneXResolution'       : (41486,Type.Rational),
+    'FocalPlaneYResolution'       : (41487,Type.Rational),
+    'FocalPlaneResolutionUnit'    : (41488,Type.Short),
+    'FocalLengthIn35mmFilm'       : (41989,Type.Short),
+    'EXIFPhotoBodySerialNumber'   : (42033,Type.Ascii),
+    'EXIFPhotoLensModel'          : (42036,Type.Ascii),
+    'DNGVersion'                  : (50706,Type.Byte),
+    'DNGBackwardVersion'          : (50707,Type.Byte),
+    'UniqueCameraModel'           : (50708,Type.Ascii),
+    'CFAPlaneColor'               : (50710,Type.Byte),
+    'CFALayout'                   : (50711,Type.Short),
+    'LinearizationTable'          : (50712,Type.Short),
+    'BlackLevelRepeatDim'         : (50713,Type.Short),
+    'BlackLevel'                  : (50714,Type.Short),
+    'WhiteLevel'                  : (50717,Type.Short),
+    'DefaultScale'                : (50718,Type.Rational),
+    'DefaultCropOrigin'           : (50719,Type.Long),
+    'DefaultCropSize'             : (50720,Type.Long),
+    'ColorMatrix1'                : (50721,Type.Srational),
+    'ColorMatrix2'                : (50722,Type.Srational),
+    'CameraCalibration1'          : (50723,Type.Srational),
+    'CameraCalibration2'          : (50724,Type.Srational),
+    'AnalogBalance'               : (50727,Type.Rational),
+    'AsShotNeutral'               : (50728,Type.Rational),
+    'BaselineExposure'            : (50730,Type.Srational),
+    'BaselineNoise'               : (50731,Type.Rational),
+    'BaselineSharpness'           : (50732,Type.Rational),
+    'BayerGreenSplit'             : (50733,Type.Long),
+    'LinearResponseLimit'         : (50734,Type.Rational),
+    'CameraSerialNumber'          : (50735,Type.Ascii),
+    'AntiAliasStrength'           : (50738,Type.Rational),
+    'ShadowScale'                 : (50739,Type.Rational),
+    'DNGPrivateData'              : (50740,Type.Byte),
+    'MakerNoteSafety'             : (50741,Type.Short),
+    'CalibrationIlluminant1'      : (50778,Type.Short),
+    'CalibrationIlluminant2'      : (50779,Type.Short),
+    'BestQualityScale'            : (50780,Type.Rational),
+    'RawDataUniqueID'             : (50781,Type.Byte),
+    'ActiveArea'                  : (50829,Type.Long),
+    'CameraCalibrationSignature'  : (50931,Type.Ascii),
+    'ProfileCalibrationSignature' : (50932,Type.Ascii),
+    'NoiseReductionApplied'       : (50935,Type.Rational),
+    'ProfileName'                 : (50936,Type.Ascii),
+    'ProfileHueSatMapDims'        : (50937,Type.Long),
+    'ProfileHueSatMapData1'       : (50938,Type.Float),
+    'ProfileHueSatMapData2'       : (50939,Type.Float),
+    'ProfileToneCurve'            : (50940,Type.Float),
+    'ProfileEmbedPolicy'          : (50941,Type.Long),
+    'ForwardMatrix1'              : (50964, Type.Srational),
+    'ForwardMatrix2'              : (50965, Type.Srational),
+    'PreviewApplicationName'      : (50966,Type.Ascii),
+    'PreviewApplicationVersion'   : (50967,Type.Ascii),
+    'PreviewSettingsDigest'       : (50969,Type.Byte),
+    'PreviewColorSpace'           : (50970,Type.Long),
+    'PreviewDateTime'             : (50971,Type.Ascii),
+    'NoiseProfile'                : (51041,Type.Double),
+    'TimeCodes'                   : (51043,Type.Byte),
+    'FrameRate'                   : (51044,Type.Srational),
+    'OpcodeList1'                 : (51008,Type.Undefined),
+    'OpcodeList2'                 : (51009,Type.Undefined),
+    'ReelName'                    : (51081,Type.Ascii),
+    'BaselineExposureOffset'      : (51109,Type.Srational), # 1.4 Spec says rational but mentions negative values?
+    'DefaultBlackRender'          : (51110,Type.Long),
+    'NewRawImageDigest'           : (51111,Type.Byte),
+}
+)
+
+ID_2_TAG = {id[0] : tag for tag, id in Tag.items()}
+
+
 class dngHeader(object):
     def __init__(self):
         self.IFDOffset = 8
 
     def raw(self):
         return struct.pack("<sI", "II\x2A\x00", self.IFDOffset)
+
 
 class dngTag(object):
     def __init__(self, tagType=Tag.Invalid, value=[]):
@@ -167,6 +168,10 @@ class dngTag(object):
 
         if (self.DataLength <= 4): self.selfContained = True
         else:                      self.selfContained = False
+
+    def __repr__(self):
+        msg = '{}:{}'.format(ID_2_TAG[self.TagId], self.Value)
+        return msg
 
     def setValue(self, value):
         if   self.DataType == Type.Byte:      self.Value = struct.pack('<%sB' % len(value), *value)
@@ -227,6 +232,12 @@ class dngIFD(object):
         self.tags = []
         self.NextIFDOffset = 0
 
+    def __repr__(self):
+        out = ''
+        for tag in sorted(self.tags, key=lambda x: x.TagId):
+            out += '{}\n'.format(tag)
+        return out
+
     def setBuffer(self, buf, offset):
         self.buf = buf
         self.offset = offset
@@ -271,7 +282,6 @@ class DNG(object):
         for ifd in self.IFDs:
             ifd.setBuffer(buf, currentOffset)
             currentOffset += ifd.dataLen()
-            
 
     def dataLen(self):
         totalLength = 8

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+from pidng.core import RPICAM2DNG
+
+class TestConvert(TestCase):
+
+    def test_convert(self):
+        pidng = RPICAM2DNG().convert("../imx477.jpg")
+


### PR DESCRIPTION
Splitted convert() into some sub functions.
Added new dataclasses Profile and FmProfile to represent camera Profiles.
Refactured classes Type and Tag into addict Dictionaries. Do not use classes if you can use something simpler and better.
Added __repr__ functions for classes using Tag and Type for better debug information.
Changed variable 'length' to 'height', since width and length are in most cultural circles the same entity.
Added a simple test