### PR TITLE
Support uncompressed float32 images

### DIFF
--- a/src/pidng/defs.py
+++ b/src/pidng/defs.py
@@ -66,3 +66,9 @@ class CalibrationIlluminant:
     D50 = 23
     ISO_Studio_Tungsten = 24
     Other = 255
+
+# DMG 1.4 allows only Uint and FloatingPoint
+class SampleFormat:
+    Uint = 1
+    Int = 2
+    FloatingPoint = 3

--- a/src/pidng/dng.py
+++ b/src/pidng/dng.py
@@ -23,6 +23,7 @@ class Tag:
     ImageWidth                  = (256,Type.Long)
     ImageLength                 = (257,Type.Long)
     BitsPerSample               = (258,Type.Short)
+    SampleFormat                = (339,Type.Short)
     Compression                 = (259,Type.Short)
     PhotometricInterpretation   = (262,Type.Short)
     FillOrder                   = (266,Type.Short)


### PR DESCRIPTION
DNG 1.4 supports floating-point images.

This might be useful for saving post-processing (HDR, etc) results.

According to DNG spec a different algorithm (deflate) should be used for floating-point data, thus a runtime error is raised if compression is requested for floating-point data.