### PR TITLE
Minor fixes to the example for converting plain raw16 file to DNG

### DIFF
--- a/examples/raw2dng.py
+++ b/examples/raw2dng.py
@@ -10,7 +10,7 @@ bpp= 12
 
 # load raw data into 16-bit numpy array.
 numPixels = width*height
-rawFile = 'extras/scene_daylight_211ms_c2.raw16'
+rawFile = '../extras/scene_daylight_211ms_c2.raw16'
 rf = open(rawFile, mode='rb')
 rawData = struct.unpack("H"*numPixels,rf.read(2*numPixels))
 rawFlatImage = np.zeros(numPixels, dtype=np.uint16)
@@ -27,8 +27,7 @@ ccm1 = [[19549, 10000], [-7877, 10000], [-2582, 10000],
 t = DNGTags()
 t.set(Tag.ImageWidth, width)
 t.set(Tag.ImageLength, height)
-t.set(Tag.TileWidth, width)
-t.set(Tag.TileLength, height)
+t.set(Tag.RowsPerStrip, height)
 t.set(Tag.Orientation, Orientation.Horizontal)
 t.set(Tag.PhotometricInterpretation, PhotometricInterpretation.Color_Filter_Array)
 t.set(Tag.SamplesPerPixel, 1)
@@ -43,11 +42,8 @@ t.set(Tag.AsShotNeutral, [[1,1],[1,1],[1,1]])
 t.set(Tag.BaselineExposure, [[-150,100]])
 t.set(Tag.Make, "Camera Brand")
 t.set(Tag.Model, "Camera Model")
-t.set(Tag.DNGVersion, DNGVersion.V1_4)
-t.set(Tag.DNGBackwardVersion, DNGVersion.V1_2)
-t.set(Tag.PreviewColorSpace, PreviewColorSpace.sRGB)
 
 # save to dng file.
 r = RAW2DNG()
-r.options(t, path="", compress=True)
+r.options(t, path="", compress=False)
 r.convert(rawImage, filename="custom")


### PR DESCRIPTION
The DNG file created by the example `raw2dng.py` did not open in RawTherapee, for instance. This commit contains minor fixes to the example: it defines Strips instead of Tiles, compression is turned off. I left out also the DNG version tags and the preview color space, since those are redundant.

Now the created DNG works fine in RawTherapee, ART, and darktable, among others.

