### PR TITLE
Remove TileWidth and TileLength tags

### DIFF
--- a/src/pidng/camdefs.py
+++ b/src/pidng/camdefs.py
@@ -107,8 +107,6 @@ class Picamera2Camera(BaseCameraModel):
         self.tags.set(Tag.RawDataUniqueID, str(self.metadata["SensorTimestamp"]).encode("ascii"))
         self.tags.set(Tag.ImageWidth, width)
         self.tags.set(Tag.ImageLength, height)
-        self.tags.set(Tag.TileWidth, width)
-        self.tags.set(Tag.TileLength, height)
         self.tags.set(Tag.Orientation, self.orientation)
         self.tags.set(Tag.SamplesPerPixel, 1)
         self.tags.set(Tag.BitsPerSample, bpp)
@@ -207,8 +205,6 @@ class RaspberryPiHqCamera(BaseCameraModel):
 
         self.tags.set(Tag.ImageWidth, width)
         self.tags.set(Tag.ImageLength, height)
-        self.tags.set(Tag.TileWidth, width)
-        self.tags.set(Tag.TileLength, height)
         self.tags.set(Tag.Orientation, self.orientation)
         self.tags.set(Tag.PhotometricInterpretation, PhotometricInterpretation.Color_Filter_Array)
         self.tags.set(Tag.SamplesPerPixel, 1)


### PR DESCRIPTION
When these are included, we should really be including the TileOffsets and TileByteCounts tags as well, otherwise the resulting behaviour can be undefined. But in our case, we are not storing images in tiled format, so it is easier just to leave them out.

This fixes DNG reading for RawTherapee 5.11.